### PR TITLE
content: consolidate One & All into TrueSense experience

### DIFF
--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -207,31 +207,19 @@ export const experience = [
         ],
     },
     {
-        years: "2023 - 2024",
+        years: "2022 - 2024",
         title: "Web Developer II",
         company: "TrueSense Marketing",
-        type: "Full-time",
+        type: "Full-time · One & All Agency through acquisition",
         link: "https://www.truesense.com",
         descriptions: [
             "Led the technical transition of 30+ clients during an agency acquisition, supporting $10M in revenue continuity through data and systems migration.",
             "Mentored junior developers and led code reviews, improving team practices and scalability.",
+            "Partnered with strategists, designers, and executives to architect a mobile app, and owned engagement and donation analytics across 30+ client accounts.",
         ],
         technologies: [
             "JavaScript",
             "Data Pipelines",
-        ],
-    },
-    {
-        years: "2022 - 2023",
-        title: "Digital Developer",
-        company: "One & All Agency",
-        type: "Full-time",
-        descriptions: [
-            "Partnered with strategists, designers, and executives to architect a mobile app, and owned engagement and donation analytics for 30+ clients.",
-        ],
-        technologies: [
-            "JavaScript",
-            "Mobile Development",
         ],
     },
     {


### PR DESCRIPTION
## Summary
- Fold One & All Agency into a single TrueSense Marketing block (**2022–2024**) so the site matches the updated general resume.
- Keep an explicit acquisition note (`Full-time · One & All Agency through acquisition`) for honesty / employment verification.
- Merge pre-acquisition bullets (mobile architecture collab + 30+ client analytics) into the TrueSense entry; drop the standalone short stint.

## Why
Two adjacent ~1-year agency rows were reading as hoppiness even though employment was continuous through the acquisition. Clarifying only when asked was too late for most screeners.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [ ] Spot-check Experience timeline on `bun run dev` (TrueSense dates, note, three bullets; no separate One & All card)